### PR TITLE
Split up ssa.Program from the base interface

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -13,7 +13,12 @@ import (
 
 // A Checker points out issues in a program.
 type Checker interface {
-	Check(*loader.Program, *ssa.Program) ([]Issue, error)
+	Program(*loader.Program)
+	Check() ([]Issue, error)
+}
+
+type WithSSA interface {
+	ProgramSSA(*ssa.Program)
 }
 
 // Issue represents an issue somewhere in a source code file.


### PR DESCRIPTION
Make it optional, depending on whether or not each checker
implementation needs SSA or not.

Fixes #5.